### PR TITLE
Added descriptions and adjusted typos

### DIFF
--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -20,10 +20,6 @@ ALTER SYSTEM ALTER CONFIGURATION ('nameserver.ini','SYSTEM') set ('auditing conf
 -- enable audit in TenantDB:
 ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'global_auditing_state') = 'true'  with reconfigure;
 
--- make sure the minimal retention period does not prevent the creation of the audit policies
--- adjust the minimal retention period to your needs
-ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'minimal_retention_period') = '7'  with reconfigure;
-
 
 -- many unsuccessful connect attempts may hint a brute force attack.
 -- the result of the policy should be evaluated by an IDS

--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -21,7 +21,8 @@ ALTER SYSTEM ALTER CONFIGURATION ('nameserver.ini','SYSTEM') set ('auditing conf
 ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'global_auditing_state') = 'true'  with reconfigure;
 
 -- make sure the minimal retention period does not prevent the creation of the audit policies
-ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'minimal_retention_period') = '20'  with reconfigure;
+-- adjust the minimal retention period to your needs
+ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'minimal_retention_period') = '7'  with reconfigure;
 
 
 -- many unsuccessful connect attempts may hint a brute force attack.

--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -10,10 +10,10 @@
 --     on a regular base.
 --     users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented directly in Tenant DB and/or System DB
--- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- While policies for specific audit actions could also be implemented in the System DB for a Tenant DB
 -- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
--- to prevent these from changes in the Tenant DB.
+-- to prevent these from changes in the Tenant DB, these
+-- policies are meant to be implemented directly in Tenant DB and/or System DB.
 
 -- enable audit in SystemDB:
 ALTER SYSTEM ALTER CONFIGURATION ('nameserver.ini','SYSTEM') set ('auditing configuration','global_auditing_state' ) = 'true'  with reconfigure;

--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -11,8 +11,9 @@
 --     users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
 -- Policies are meant to be implemented directly in Tenant DB and/or System DB
--- while some audit actions could also be implemented in the System DB for a Tenant DB
--- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB.
+-- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
+-- to prevent these from changes in the Tenant DB.
 
 -- enable audit in SystemDB:
 ALTER SYSTEM ALTER CONFIGURATION ('nameserver.ini','SYSTEM') set ('auditing configuration','global_auditing_state' ) = 'true'  with reconfigure;

--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -172,7 +172,7 @@ ALTER AUDIT POLICY "_SAP_configuration changes" ENABLE;
 
 -- needed for system changelog
 -- mandatory
--- Tenant System DB
+-- Tenant and System DB
 -- this policy should not cause many entries in the audit log
 CREATE AUDIT POLICY "_SAP_license addition" 
   AUDITING ALL
@@ -188,7 +188,7 @@ ALTER AUDIT POLICY "_SAP_license deletion" ENABLE;
 
 -- needed for system changelog
 -- mandatory
--- Tenant System DB
+-- Tenant and System DB
 -- this policy should not cause many entries in the audit log
 CREATE AUDIT POLICY "_SAP_recover database" 
   AUDITING ALL

--- a/1_hana_audit_policy_mandatory.sql
+++ b/1_hana_audit_policy_mandatory.sql
@@ -10,12 +10,17 @@
 --     on a regular base.
 --     users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented in Tenant DB and/or System DB
+-- Policies are meant to be implemented directly in Tenant DB and/or System DB
+-- while some audit actions could also be implemented in the System DB for a Tenant DB
+-- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB.
 
 -- enable audit in SystemDB:
 ALTER SYSTEM ALTER CONFIGURATION ('nameserver.ini','SYSTEM') set ('auditing configuration','global_auditing_state' ) = 'true'  with reconfigure;
 -- enable audit in TenantDB:
 ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'global_auditing_state') = 'true'  with reconfigure;
+
+-- make sure the minimal retention period does not prevent the creation of the audit policies
+ALTER SYSTEM ALTER CONFIGURATION ('global.ini', 'system') set ('auditing configuration', 'minimal_retention_period') = '20'  with reconfigure;
 
 
 -- many unsuccessful connect attempts may hint a brute force attack.

--- a/2_s4hana_hana_audit_policy_recommended.sql
+++ b/2_s4hana_hana_audit_policy_recommended.sql
@@ -10,10 +10,10 @@
 --     on a regular base.
 --     users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented directly in Tenant DB and/or System DB
--- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- While policies for specific audit actions could also be implemented in the System DB for a Tenant DB
 -- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
--- to prevent these from changes in the Tenant DB.
+-- to prevent these from changes in the Tenant DB, these
+-- policies are meant to be implemented directly in Tenant DB and/or System DB.
 
 
 -- monitoring of direct access to S4HANA data. 

--- a/2_s4hana_hana_audit_policy_recommended.sql
+++ b/2_s4hana_hana_audit_policy_recommended.sql
@@ -16,13 +16,13 @@
 -- monitoring of direct access to S4HANA data. 
 -- only <SAPABAP1> or <SAPABAP1SHD> user should access 
 -- frequently. These actions should be contained in
--- the application log
+-- the application log.
 -- Exclude other technical users in case
--- of e.g. SDA access to the schema
+-- of e.g. SDA access to the schema.
 -- Auditing SELECT as read access log if DPP relevant data
--- is accessed directly on the database
--- mandatory
--- Tenant DB
+-- is accessed directly on the database.
+-- recommended
+-- Tenant DB holding the schema for S/4HANA 
 -- this should lead to some entries for support user accessing the
 -- <SAPABAP1> schema. Access via DBACOCKPIT transaction with DBACOCKPIT
 -- user on HANA should also appear.

--- a/2_s4hana_hana_audit_policy_recommended.sql
+++ b/2_s4hana_hana_audit_policy_recommended.sql
@@ -10,7 +10,10 @@
 --     on a regular base.
 --     users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented in Tenant DB and/or System DB
+-- Policies are meant to be implemented directly in Tenant DB and/or System DB
+-- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
+-- to prevent these from changes in the Tenant DB.
 
 
 -- monitoring of direct access to S4HANA data. 

--- a/3_s4hana_hana_audit_policy_optional.sql
+++ b/3_s4hana_hana_audit_policy_optional.sql
@@ -225,8 +225,6 @@ ALTER AUDIT POLICY "_SAPS4_Opt_11 Password Blocklist" ENABLE;
 -- optional: needed for monitoring
 -- In certain circumstances it might make sense to log successful connect attempts
 -- but technical users connecting frequently should be excluded
--- internal users like _SYS_* should be excluded
--- user SAPDBCTRL for SAP Host Agent should be excluded
 -- Tenant and System DB
 CREATE AUDIT POLICY "_SAPS4_Opt_12 session connect successful" 
   AUDITING SUCCESSFUL

--- a/3_s4hana_hana_audit_policy_optional.sql
+++ b/3_s4hana_hana_audit_policy_optional.sql
@@ -10,10 +10,10 @@
 --     on a regular base.
 -- users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented directly in Tenant DB and/or System DB
--- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- While policies for specific audit actions could also be implemented in the System DB for a Tenant DB
 -- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
--- to prevent these from changes in the Tenant DB.
+-- to prevent these from changes in the Tenant DB, these
+-- policies are meant to be implemented directly in Tenant DB and/or System DB.
  
 -- optional: needed for extended system changelog
 -- Tenant and System DB

--- a/3_s4hana_hana_audit_policy_optional.sql
+++ b/3_s4hana_hana_audit_policy_optional.sql
@@ -53,8 +53,8 @@ CREATE AUDIT POLICY "_SAPS4_Opt_02 Data Definition"
       CREATE SCHEMA,
       CREATE SEQUENCE,
       CREATE STATISTICS,
---    Auditing Synonym is only supported with HANA2 Rev45+
---    CREATE SYNONYM,
+--    Auditing Synonym is only supported with HANA 2.0 SPS04 Rev45+
+      CREATE SYNONYM,
       CREATE TABLE,
       CREATE TRIGGER,
       CREATE VIEW,

--- a/3_s4hana_hana_audit_policy_optional.sql
+++ b/3_s4hana_hana_audit_policy_optional.sql
@@ -221,7 +221,9 @@ ALTER AUDIT POLICY "_SAPS4_Opt_11 Password Blocklist" ENABLE;
 
 -- optional: needed for monitoring
 -- In certain circumstances it might make sense to log successful connect attempts
--- but technical users connecting  frequently should be excluded
+-- but technical users connecting frequently should be excluded
+-- internal users like _SYS_* should be excluded
+-- user SAPDBCTRL for SAP Host Agent should be excluded
 -- Tenant and System DB
 CREATE AUDIT POLICY "_SAPS4_Opt_12 session connect successful" 
   AUDITING SUCCESSFUL

--- a/3_s4hana_hana_audit_policy_optional.sql
+++ b/3_s4hana_hana_audit_policy_optional.sql
@@ -10,7 +10,10 @@
 --     on a regular base.
 -- users must be added comma separated
 -- the schema defined by <SAPABAP1>.* must be replaced by the actual DB schema of S4
--- Policies are meant to be implemented in Tenant DB and/or System DB
+-- Policies are meant to be implemented directly in Tenant DB and/or System DB
+-- while policies for specific audit actions could also be implemented in the System DB for a Tenant DB
+-- by adding "FOR <TENANTDB>" to the create audit policy statement in the System DB
+-- to prevent these from changes in the Tenant DB.
  
 -- optional: needed for extended system changelog
 -- Tenant and System DB


### PR DESCRIPTION
Added description that the policies are meant to be created directly in the Tenant DB instead of in the System DB for the Tenant DB.
_SAPS4_01 Schema Access Log in 2_s4hana_hana_audit_policy_recommended.sql was classified as mandatory. Changed to recommended. 
Adjusted some typos.